### PR TITLE
テクスチャの色の変更処理を追加

### DIFF
--- a/CM3D2.AlwaysColorChange.Plugin.cs
+++ b/CM3D2.AlwaysColorChange.Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -75,6 +75,8 @@ namespace CM3D2.AlwaysColorChange.Plugin
         private bool bApplyChange = false;
 
         private CCPreset targetPreset;
+
+        private TextureModifier textureModifier;
 
         public AlwaysColorChange()
         {
@@ -225,6 +227,7 @@ namespace CM3D2.AlwaysColorChange.Plugin
             Nodenames.Add("右小指先", "Bip01 R Finger42");
 
             SaveFileName = Path.Combine(DataPath, "AlwaysColorChange.xml");
+            textureModifier = new TextureModifier();
         }
 
         private void changeColor(string slotname)
@@ -326,6 +329,12 @@ namespace CM3D2.AlwaysColorChange.Plugin
             bApplyChange = false;
         }
 
+        void OnDestroy()
+        {
+            // テクスチャキャッシュを開放する
+            textureModifier.Clear();
+        }
+
         private void Update()
         {
             if (!Enum.IsDefined(typeof(TargetLevel), Application.loadedLevel))
@@ -366,6 +375,50 @@ namespace CM3D2.AlwaysColorChange.Plugin
             if (bApplyChange && !maid.boAllProcPropBUSY)
             {
                 ApplyPreset();
+            }
+
+            // テクスチャエディットの反映
+            if (menuType != MenuType.Texture)
+            {
+                // テクスチャモードでなければ、テクスチャ変更対象を消す
+                textureEdit.Clear();
+            }
+            else
+            {
+                // 各スロットのマテリアルの列挙
+                var slotMaterials = new Dictionary<string, List<Material>>();
+                foreach (string slotName in Slotnames.Keys)
+                {
+                    slotMaterials[slotName] = GetMaterials(slotName);
+                }
+
+                // マテリアルで使用されている全テクスチャの列挙
+                var textures = new List<Texture2D>();
+                foreach (List<Material> materials in slotMaterials.Values)
+                {
+                    if (materials == null)
+                    {
+                        continue;
+                    }
+                    foreach (Material material in materials)
+                    {
+                        foreach (string propName in propNames)
+                        {
+                            var texture2d = material.GetTexture(propName) as Texture2D;
+                            if (texture2d != null)
+                            {
+                                textures.Add(texture2d);
+                            }
+                        }
+                    }
+                }
+                textureModifier.Update(
+                    maid,
+                    slotMaterials,
+                    textures,
+                    textureEdit.slotName,
+                    textureEdit.materialIndex,
+                    textureEdit.propName);
             }
         }
 
@@ -437,6 +490,28 @@ namespace CM3D2.AlwaysColorChange.Plugin
 
 //        string[] propNames = new string[] { "_MainTex", "_ShadowTex", "_ToonRamp", "_ShadowRateToon", "Alpha", "Multiply", "InfinityColor", "TexTo8bitTex", "Max" };
         string[] propNames = new string[] { "_MainTex", "_ShadowTex", "_ToonRamp", "_ShadowRateToon" };
+
+        class TextureEdit
+        {
+            public string slotName;
+            public int materialIndex;
+            public string propName;
+
+            public TextureEdit()
+            {
+                Clear();
+            }
+
+            // テクスチャエディット対象を無効にする
+            public void Clear()
+            {
+                slotName = string.Empty;
+                materialIndex = -1;
+                propName = string.Empty;
+            }
+        }
+        TextureEdit textureEdit = new TextureEdit();
+
         private void DoSelectTexture(int winId)
         {
             float margin = FixPx(marginPx);
@@ -451,43 +526,84 @@ namespace CM3D2.AlwaysColorChange.Plugin
             GUIStyle tStyle = "toggle";
             GUIStyle textStyle = "textField";
             textStyle.fontSize = FixPx(fontPx);
+            GUILayoutOption buttonWidth = GUILayout.Width(conRect.width * 0.1f);
+            GUILayoutOption buttonWidth2 = GUILayout.Width(conRect.width * 0.2f);
 
             GUI.Label(outRect, "テクスチャ変更", lStyle);
+            scrollViewVector = GUI.BeginScrollView(scrollRect, scrollViewVector, conRect);
+
+            // materials には null チェックが必要。例えば以下の操作を行う
+            // (1) ゲーム側でワンピースを選択
+            // (2) AlwaysColorChange側でワンピース→テクスチャ変更を選択
+            // (3) ゲーム側でボトムスから衣装を選択
+            // この時点でcurrentSlotnameが指すmaterialsが無くなるため、nullとなる
 
             var materials = GetMaterials(currentSlotname);
-
-            conRect.height += (itemHeight + margin) * (materials.Count() * (propNames.Count() * 2 + 2)) + margin * 2;
-
-            scrollViewVector = GUI.BeginScrollView(scrollRect, scrollViewVector, conRect);
-            outRect.y = 0;
-            for (int i = 0; i < materials.Count(); i++)
+            if (materials != null)
             {
-                outRect.x = margin;
-                outRect.width = scrollRect.width;
-                GUI.Label(outRect, materials[i].name, lStyle);
-                outRect.y += itemHeight + margin;
-                foreach (string propName in propNames)
+                conRect.height += (itemHeight + margin) * (materials.Count() * (propNames.Count() * 2 + 2)) + margin * 2;
+                for (int i = 0; i < materials.Count(); i++)
                 {
-                    outRect.x = margin;
-                    outRect.width = scrollRect.width;
-                    GUI.Label(outRect, propName, lStyle);
-                    outRect.y += itemHeight + margin;
-                    outRect.width = conRect.width * 0.8f - margin * 2;
-                    textureFile[i][propName] = GUI.TextField(outRect, textureFile[i][propName], textStyle);
-                    outRect.x += outRect.width + margin;
-                    outRect.width = conRect.width * 0.1f;
-                    if (GUI.Button(outRect, "適", bStyle))
+                    GUILayout.Label(materials[i].name, lStyle);
+                    foreach (string propName in propNames)
                     {
-                        targetMatno = i;
-                        targetPropName = propName;
-                        ChangeTex(texturePath, textureFile[targetMatno][targetPropName]);
+                        bool bTargetElement = (i == textureEdit.materialIndex && propName == textureEdit.propName);
+                        GUILayout.BeginHorizontal();
+                        {
+                            // エディット用スライダーの開閉
+                            if (!textureModifier.IsValidTarget(maid, currentSlotname, materials[i], propName))
+                            {
+                                // 参照先が Texture2D が取れなかった (例 : RenderTexture だった) 場合はとりあえず
+                                // あきらめて何もしない。無理やり書いても良いのかもしれないけど……
+                                var tmp = GUI.enabled;
+                                GUI.enabled = false;
+                                GUILayout.Button("+変更", bStyle, buttonWidth2);
+                                GUI.enabled = tmp;
+                            }
+                            else if (bTargetElement)
+                            {
+                                // エディット中のテクスチャの場合
+                                if (GUILayout.Button("-変更", bStyle, buttonWidth2))
+                                {
+                                    textureEdit.Clear();
+                                }
+                            }
+                            else
+                            {
+                                // エディット中以外のテクスチャの場合
+                                if (GUILayout.Button("+変更", bStyle, buttonWidth2))
+                                {
+                                    textureEdit.slotName = currentSlotname;
+                                    textureEdit.materialIndex = i;
+                                    textureEdit.propName = propName;
+                                }
+                            }
+                            GUILayout.Label(propName, lStyle);
+                        }
+                        GUILayout.EndHorizontal();
+
+                        // テクスチャエディット用スライダー
+                        if (bTargetElement)
+                        {
+                            textureModifier.ProcGUI(maid, currentSlotname, materials[i], propName, margin, fontSize, itemHeight);
+                        }
+
+                        GUILayout.BeginHorizontal();
+                        {
+                            textureFile[i][propName] = GUILayout.TextField(textureFile[i][propName], textStyle);
+                            if (GUILayout.Button("適", bStyle, buttonWidth))
+                            {
+                                targetMatno = i;
+                                targetPropName = propName;
+                                ChangeTex(texturePath, textureFile[targetMatno][targetPropName]);
+                            }
+                            if (GUILayout.Button("...", bStyle, buttonWidth))
+                            {
+                                OpenFileBrowser(i, propName);
+                            }
+                        }
+                        GUILayout.EndHorizontal();
                     }
-                    outRect.x += outRect.width + margin;
-                    if (GUI.Button(outRect, "...", bStyle))
-                    {
-                        OpenFileBrowser(i, propName);
-                    }
-                    outRect.y += itemHeight + margin;
                 }
             }
             GUI.EndScrollView();
@@ -1254,7 +1370,6 @@ namespace CM3D2.AlwaysColorChange.Plugin
             bApplyChange = false;
         }
 
-        private string SaveFileName = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) + @"\Config\AlwaysColorChange.xml";
         private string SaveFileName;
 
         private void SavePreset()

--- a/CM3D2.AlwaysColorChange.Plugin.cs
+++ b/CM3D2.AlwaysColorChange.Plugin.cs
@@ -224,6 +224,7 @@ namespace CM3D2.AlwaysColorChange.Plugin
             Nodenames.Add("右小指関節", "Bip01 R Finger41");
             Nodenames.Add("右小指先", "Bip01 R Finger42");
 
+            SaveFileName = Path.Combine(DataPath, "AlwaysColorChange.xml");
         }
 
         private void changeColor(string slotname)
@@ -1254,6 +1255,7 @@ namespace CM3D2.AlwaysColorChange.Plugin
         }
 
         private string SaveFileName = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) + @"\Config\AlwaysColorChange.xml";
+        private string SaveFileName;
 
         private void SavePreset()
         {

--- a/TextureModifier.cs
+++ b/TextureModifier.cs
@@ -1,0 +1,513 @@
+﻿// テクスチャの色変え処理
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace CM3D2.AlwaysColorChange.Plugin
+{
+    internal class TextureModifier
+    {
+        private FilterParams filterParams = new FilterParams();
+        private OriginalTextureCache originalTextureCache = new OriginalTextureCache();
+
+        public void Clear()
+        {
+            originalTextureCache.Clear();
+        }
+
+        public bool IsValidTarget(Maid maid, string slotName, Material material, string propName)
+        {
+            return GetKey(maid, slotName, material, propName) != null;
+        }
+
+        public void ProcGUI(Maid maid, string slotName, Material material, string propName, float margin, float fontSize, float itemHeight)
+        {
+            FilterParam fp = Get(maid, slotName, material, propName);
+            if (fp != null)
+            {
+                fp.ProcGUI(margin, fontSize, itemHeight);
+            }
+        }
+
+        public void Update(
+            Maid maid,
+            Dictionary<string, List<Material>> slotMaterials,
+            List<Texture2D> textures,
+            string slotName, int materialIndex, string propName
+        )
+        {
+            originalTextureCache.Refresh(textures.ToArray());
+
+            // マウスボタンが離されたタイミングでフィルターを適用する
+            if (Input.GetMouseButtonUp(0))
+            {
+                FilterTexture(slotMaterials, textures, maid, slotName, materialIndex, propName);
+            }
+        }
+
+        private string GetKey(Maid maid, string slotName, Material material, string propName)
+        {
+            if (maid == null || material == null || string.IsNullOrEmpty(propName))
+            {
+                return null;
+            }
+            Texture2D tex2d = material.GetTexture(propName) as Texture2D;
+            if (tex2d == null || string.IsNullOrEmpty(tex2d.name))
+            {
+                return null;
+            }
+            return string.Format("{0}/{1}/{2}/{3}"
+                                 , maid.Param.status.guid
+                                 , slotName
+                                 , material.name
+                                 , tex2d.name);
+        }
+
+        private FilterParam Get(Maid maid, string slotName, Material material, string propName)
+        {
+            string key = GetKey(maid, slotName, material, propName);
+            return filterParams.GetOrAdd(key);
+        }
+
+        private void FilterTexture(
+            Dictionary<string, List<Material>> slotMaterials,
+            List<Texture2D> textures, Maid maid, string slotName, int materialIndex, string propName
+        )
+        {
+            Material material = null;
+            Texture2D texture = null;
+            {
+                List<Material> materials;
+                if (slotMaterials.TryGetValue(slotName, out materials) && materials != null)
+                {
+                    material = materials.ElementAtOrDefault(materialIndex);
+                    if (material != null)
+                    {
+                        texture = material.GetTexture(propName) as Texture2D;
+                    }
+                }
+            }
+            if (material == null || texture == null)
+            {
+                return;
+            }
+
+            FilterParam filterParam = Get(maid, slotName, material, propName);
+            if (!filterParam.Dirty.Value)
+            {
+                return;
+            }
+
+            originalTextureCache.SetDirty(texture);
+            filterParam.ClearDirtyFlag();
+
+            float outputBase = filterParam.OutputMin * 0.01f;
+            float outputScale = (filterParam.OutputMax - filterParam.OutputMin) * 0.01f;
+
+            float inputExp = Mathf.Log(filterParam.InputMid * 0.01f) / Mathf.Log(0.5f);
+            float inputBase = (-filterParam.InputMin / (filterParam.InputMax - filterParam.InputMin));
+            float inputScale = 1f / ((filterParam.InputMax - filterParam.InputMin) * 0.01f);
+
+            float hue = filterParam.Hue / 360f;
+            float saturation = filterParam.Saturation / 100f;
+            float lightness = filterParam.Lightness / 100f;
+
+            Filter(texture, originalTextureCache.GetOriginalTexture(texture), (color) =>
+            {
+                Color c = color;
+
+                c.r = Mathf.Clamp01(c.r * inputScale + inputBase);
+                c.g = Mathf.Clamp01(c.g * inputScale + inputBase);
+                c.b = Mathf.Clamp01(c.b * inputScale + inputBase);
+
+                c.r = Mathf.Pow(c.r, inputExp);
+                c.g = Mathf.Pow(c.g, inputExp);
+                c.b = Mathf.Pow(c.b, inputExp);
+
+                Vector4 hsl = ColorUtil.ColorToHsl(c);
+                hsl.x = (hsl.x + hue) % 1f;
+                hsl.y *= saturation;
+                hsl.z *= lightness;
+                c = ColorUtil.HslToColor(hsl);
+
+                c.r = c.r * outputScale + outputBase;
+                c.g = c.g * outputScale + outputBase;
+                c.b = c.b * outputScale + outputBase;
+
+                return c;
+            });
+        }
+
+        private void Filter(Texture2D dstTexture, Texture2D srcTexture, Func<Color32, Color32> mapFunc)
+        {
+            if (dstTexture == null || srcTexture == null || dstTexture.width != srcTexture.width || dstTexture.height != srcTexture.height)
+            {
+                return;
+            }
+            int maxIndex = dstTexture.width * dstTexture.height;
+            Color32[] src = srcTexture.GetPixels32(0);
+            Color32[] dst = dstTexture.GetPixels32(0);
+            for (int i = 0; i < maxIndex; i++)
+            {
+                dst[i] = mapFunc(src[i]);
+            }
+            dstTexture.SetPixels32(dst);
+            dstTexture.Apply();
+        }
+
+        private class FilterParams
+        {
+            private Dictionary<string, FilterParam> params_;
+
+            public FilterParams()
+            {
+                Clear();
+            }
+
+            public void Clear()
+            {
+                params_ = new Dictionary<string, FilterParam>();
+            }
+
+            public FilterParam GetOrAdd(string key)
+            {
+                FilterParam p;
+                if (params_.TryGetValue(key, out p))
+                {
+                    return p;
+                }
+                p = new FilterParam();
+                params_[key] = p;
+                return p;
+            }
+        }
+
+        private class FilterParam
+        {
+            public bool IsDirty { get { return Dirty.Value; } }
+
+            public DirtyFlag Dirty;
+            public DirtyValue Hue;
+            public DirtyValue Saturation;
+            public DirtyValue Lightness;
+            public DirtyValue InputMin;
+            public DirtyValue InputMax;
+            public DirtyValue InputMid;
+            public DirtyValue OutputMin;
+            public DirtyValue OutputMax;
+
+            public FilterParam()
+            {
+                Clear();
+            }
+
+            public void Clear()
+            {
+                Dirty = new DirtyFlag();
+                Hue = new DirtyValue(Dirty, "色相", 0f, 0f, 360f);
+                Saturation = new DirtyValue(Dirty, "彩度", 100f, 0f, 200f);
+                Lightness = new DirtyValue(Dirty, "明度", 100f, 0f, 200f);
+                InputMin = new DirtyValue(Dirty, "InpMin", 0f, 0f, 100f);
+                InputMax = new DirtyValue(Dirty, "InpMax", 100f, 0f, 100f);
+                InputMid = new DirtyValue(Dirty, "InpMid", 50f, 0f, 100f);
+                OutputMin = new DirtyValue(Dirty, "OutMin", 0f, 0f, 100f);
+                OutputMax = new DirtyValue(Dirty, "OutMax", 100f, 0f, 100f);
+            }
+
+            public void ClearDirtyFlag()
+            {
+                Dirty.Value = false;
+            }
+
+            public void ProcGUI(float margin, float fontSize, float itemHeight)
+            {
+                guiSlider(margin, Hue);
+                guiSlider(margin, Saturation);
+                guiSlider(margin, Lightness);
+                guiSlider(margin, InputMin);
+                guiSlider(margin, InputMax);
+                guiSlider(margin, InputMid);
+                guiSlider(margin, OutputMin);
+                guiSlider(margin, OutputMax);
+
+                GUILayout.Space(margin * 2f);
+                GUILayout.BeginHorizontal();
+                GUILayout.Space(margin * 8f);
+                if (GUILayout.Button("リセット"))
+                {
+                    Clear();
+                    Dirty.Value = true;
+                }
+                GUILayout.Space(margin * 8f);
+                GUILayout.EndHorizontal();
+                GUILayout.Space(margin * 2f);
+            }
+
+            private static void guiSlider(float margin, DirtyValue dirtyValue)
+            {
+                float val = dirtyValue.Value;
+                GUILayout.BeginHorizontal();
+                GUILayout.Label(dirtyValue.Name, GUILayout.Width(64));
+                GUILayout.Label(string.Format("{0:F0}", val), GUILayout.Width(32));
+                val = GUILayout.HorizontalSlider(val, dirtyValue.Min, dirtyValue.Max);
+                GUILayout.Space(margin * 2f);
+                GUILayout.EndHorizontal();
+                dirtyValue.Value = val;
+            }
+        }
+
+        private class DirtyFlag
+        {
+            public bool Value = false;
+        }
+
+        private class DirtyValue
+        {
+            private DirtyFlag dirtyFlag;
+            private float val;
+
+            public string Name { get; private set; }
+            public float Min { get; private set; }
+            public float Max { get; private set; }
+            public float Value
+            {
+                get
+                {
+                    return val;
+                }
+                set
+                {
+                    float v = Mathf.Clamp(value, Min, Max);
+                    if (!val.Equals(v))
+                    {
+                        val = v;
+                        dirtyFlag.Value = true;
+                    }
+                }
+            }
+
+            public DirtyValue(DirtyFlag dirtyFlag, string name, float val, float min, float max)
+            {
+                Name = name;
+                Min = min;
+                Max = max;
+                this.dirtyFlag = dirtyFlag;
+                this.val = val;
+            }
+
+            public static implicit operator float (DirtyValue dirtyValue)
+            {
+                return dirtyValue.val;
+            }
+        }
+
+        private class OriginalTextureCache
+        {
+            private Dictionary<string, Texture2D> OriginalTextures;
+            private Dictionary<string, bool> DirtyTextures;
+
+            public OriginalTextureCache()
+            {
+                Clear();
+            }
+
+            public void Clear()
+            {
+                if (OriginalTextures != null)
+                {
+                    // テクスチャの開放
+                    foreach (Texture2D tex in OriginalTextures.Values)
+                    {
+                        try
+                        {
+                            UnityEngine.Object.Destroy(tex);
+                        }
+                        catch { }
+                    }
+                }
+                OriginalTextures = new Dictionary<string, Texture2D>();
+                DirtyTextures = new Dictionary<string, bool>();
+            }
+
+            public void Refresh(Texture2D[] maidTextures)
+            {
+                // 既に使われなくなったテクスチャを削除
+                var names = new List<string>();
+                foreach (string name in OriginalTextures.Keys)
+                {
+                    bool b = false;
+                    foreach (Texture2D t in maidTextures)
+                    {
+                        if (t.name == name)
+                        {
+                            b = true;
+                            break;
+                        }
+                    }
+                    if (!b)
+                    {
+                        names.Add(name);
+                    }
+                }
+                foreach (string name in names)
+                {
+                    Texture2D tex;
+                    if (OriginalTextures.TryGetValue(name, out tex))
+                    {
+                        UnityEngine.Object.Destroy(tex);
+                    }
+                    OriginalTextures.Remove(name);
+                    DirtyTextures.Remove(name);
+                }
+
+                // 知らないテクスチャを追加
+                foreach (Texture2D t in maidTextures)
+                {
+                    if (!OriginalTextures.ContainsKey(t.name) && !IsDirty(t))
+                    {
+                        OriginalTextures[t.name] = UnityEngine.Object.Instantiate(t) as Texture2D;
+                        DirtyTextures[t.name] = false;
+                    }
+                }
+            }
+
+            public void SetDirty(Texture2D texture)
+            {
+                if (texture != null)
+                {
+                    SetDirty(texture.name);
+                }
+            }
+
+            public void SetDirty(string name)
+            {
+                DirtyTextures[name] = true;
+            }
+
+            public bool IsDirty(Texture2D texture)
+            {
+                return texture != null && IsDirty(texture.name);
+            }
+
+            public bool IsDirty(string name)
+            {
+                bool b;
+                if (DirtyTextures.TryGetValue(name, out b))
+                {
+                    return b;
+                }
+                return false;
+            }
+
+            public Texture2D GetOriginalTexture(Texture2D texture)
+            {
+                return texture != null ? GetOriginalTexture(texture.name) : null;
+            }
+
+            public Texture2D GetOriginalTexture(string name)
+            {
+                Texture2D t;
+                if (OriginalTextures.TryGetValue(name, out t))
+                {
+                    return t;
+                }
+                return null;
+            }
+        }
+
+        private static class ColorUtil
+        {
+            // Color -> HSL 変換
+            public static Vector4 ColorToHsl(Color c)
+            {
+                c.r = Mathf.Clamp01(c.r);
+                c.g = Mathf.Clamp01(c.g);
+                c.b = Mathf.Clamp01(c.b);
+
+                float max = Mathf.Max(c.r, Mathf.Max(c.g, c.b));
+                float min = Mathf.Min(c.r, Mathf.Min(c.g, c.b));
+
+                float h = 0f;
+                float s = 0f;
+                float l = (max + min) / 2f;
+                float d = max - min;
+                if (d != 0f)
+                {
+                    s = (l > 0.5f) ? (d / (2f - max - min)) : (d / (max + min));
+                    if (max == c.r)
+                    {
+                        h = (c.g - c.b) / d + (c.g < c.b ? 6f : 0f);
+                    }
+                    else if (max == c.g)
+                    {
+                        h = (c.b - c.r) / d + 2f;
+                    }
+                    else
+                    {
+                        h = (c.r - c.g) / d + 4f;
+                    }
+                    h /= 6f;
+                }
+                return new Vector4(h, s, l, c.a);
+            }
+
+            // HSL -> Color 変換
+            public static Color HslToColor(Vector4 hsl)
+            {
+                Color c;
+                c.a = hsl.w;
+
+                float h = hsl.x;
+                float s = hsl.y;
+                float l = hsl.z;
+
+                if (s == 0f)
+                {
+                    c.r = l;
+                    c.g = l;
+                    c.b = l;
+                }
+                else
+                {
+                    float y = (l < 0.5f) ? (l * (1f + s)) : ((l + s) - l * s);
+                    float x = 2f * l - y;
+                    c.r = Hue(x, y, h + 1f / 3f);
+                    c.g = Hue(x, y, h);
+                    c.b = Hue(x, y, h - 1f / 3f);
+                }
+
+                return c;
+            }
+
+            private static float Hue(float x, float y, float t)
+            {
+                if (t < 0f)
+                {
+                    t += 1f;
+                }
+                else if (t > 1f)
+                {
+                    t -= 1f;
+                }
+
+                if (t < 1f / 6f)
+                {
+                    return x + (y - x) * 6f * t;
+                }
+                else if (t < 2f / 6f)
+                {
+                    return y;
+                }
+                else if (t < 4f / 6f)
+                {
+                    return x + (y - x) * 6f * (2f / 3f - t);
+                }
+                else
+                {
+                    return x;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
テクスチャの色の変更処理を追加するパッチです
## 動作確認方法
- 服装→ワンピース→フリルベビードール（ピンク色のもの）を選択
- AlwaysColorChangeを出し、ワンピース→テクスチャ変更を選択
  - 「Dress015_onep_2」内の「_MainTex」の左にある「+変更」ボタンを押す
  - 「色相」スライダーを変更し色が変わるのを確認
## 実装の内容
- コミットログはヘッポコ英語で書きましたが、意味不明であれば日本語で書き直します

本来PRを分けるべきですが、まず以下の変更を行いました
- SaveFileName を UnityInjector.PluginBase.DataPath および Path.Combine を使って初期化するように変更
  - "Config" を明示しなくて済むようになるので、個人的には望ましいと考えています
  - Path.Combine はパス要素を連結する C# の標準関数です
  - メンテナンス負荷が上がるようなら元に戻します

上記の変更後、以下の変更を行いました
- テクスチャ変更処理をまとめた TextureModifier.cs を追加
  - TextureModifier 側から AlwaysColorChange へのアクセスは行わない方針で書いています
- CM3D2.AlwaysColorChange.Plugin.cs
  - ファイル末尾に改行を追加
    - ファイル末尾の改行は、git で推奨されているために追加しました
  - AlwaysColorChange.TextureEdit
    - テクスチャ変更のエディット処理用のパラメーターをまとめたものです
    - クラスでまとめずに、生の値を AlwaysColorChange 直下に置いたほうが良いかもしれません
  - AlwaysColorChange.Update()
    - テクスチャキャッシュ、テクスチャ操作処理を追加
    - マテリアル、テクスチャの列挙方法は AlwaysColorChange 内の処理に依存しているので、TextureModifier 側ではなく AlwaysColorChange 側で列挙して TextureModifierに与えています
  - AlwaysColorChange.DoSelectTexture()
    - materials の null チェックを追加
    - GUILayout を使ったレイアウトに変更
    - テクスチャ操作のスライダーの GUI 処理は TextureModifier に委譲
  - AlwaysColorChange.OnDestroy()
    - テクスチャキャッシュで生成したキャッシュに対して、UnityEngine.Object.Destroy() を用いた開放処理が必要なので追加
    - IDisposable のほうが良いのかなという気もしますが、Unity ではどちらが良いのか分からないのでとりあえずこうしています
## 課題
- テクスチャを PNG としての保存するための UI
  - どういう実装が良いのか分からなかったので保留にしています
- テクスチャ操作パラメーターを保存すべきか検討
  - テクスチャ読み込みがあるので、必要ない気もします
- Texture2D ではないテクスチャを操作対象にすべきか検討
  - ボディや目などはRenderTextureになっているので、操作した後さらに本体側で色を調整したいケースで問題がありそうです

課題については、方針を言ってもらえればPR中のブランチを修正します

---

以上です。お時間があるときに、レビューをお願いします
